### PR TITLE
Yarnの利用を削除した

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 node_modules/
 dist/
 extension/
-.yarn/
 .pnp.js

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ haters/
 logs
 *.log
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
 lerna-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
@@ -63,9 +61,6 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
-.yarn-integrity
-
 # dotenv environment variables file
 .env
 .env.test
@@ -104,10 +99,3 @@ public/
 extension
 dist/
 .awcache
-
-# yarn 2
-# https://github.com/yarnpkg/berry/issues/454#issuecomment-530312089
-.yarn/*
-!.yarn/releases
-!.yarn/plugins
-.pnp.* 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 git:
   depth: 3
 script:
-  - yarn run build
+  - npm run build
 deploy:
   provider: pages
   skip-cleanup: true

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "url": "https://twitter.com/Getaji"
   },
   "engines": {
-    "node": ">=10.0.0",
-    "yarn": ">=1.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "dev:chrome": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=chrome webpack --watch",
@@ -19,7 +18,7 @@
     "build:chrome": "cross-env NODE_ENV=production cross-env TARGET_BROWSER=chrome webpack",
     "build:firefox": "cross-env NODE_ENV=production cross-env TARGET_BROWSER=firefox webpack",
     "build:opera": "cross-env NODE_ENV=production cross-env TARGET_BROWSER=opera webpack",
-    "build": "yarn run build:chrome && yarn run build:firefox && yarn run build:opera",
+    "build": "npm run build:chrome && npm run build:firefox && npm run build:opera",
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --ext .js --fix"
   },


### PR DESCRIPTION
resolved #9

Yarnを使わなくしたので、すべての利用箇所から削除した
npmの `build` スクリプトも `npm` を利用するようにしたので、Yarnが入っていない環境でも `build` が動くようになった。